### PR TITLE
fix (#3): make response body JSON parsable

### DIFF
--- a/netlify/functions/joke.js
+++ b/netlify/functions/joke.js
@@ -10,6 +10,6 @@ export const handler = async (event) => {
     // Other properties such as headers or body can also be included.
     return {
         statusCode: 200,
-        body: randomJoke
+        body: JSON.stringify(randomJoke)
     }
 }


### PR DESCRIPTION
My mistake for missing this in the original PR. 

When the function is called, users will typically try to parse it via:

```js
fetch('/api/joke').then(res => res.json())
```

As it currently stands, this would trigger an error since the response is not JSON parsable. So we need to make it a raw string which will allow the above code to work as expected.